### PR TITLE
[FIX] FutureWarning:  Not sort by default.

### DIFF
--- a/notebooks/step2.ipynb
+++ b/notebooks/step2.ipynb
@@ -32,7 +32,7 @@
     "df_train = pd.read_csv('../input/train.csv', parse_dates=['datetime'])\n",
     "df_test = pd.read_csv('../input/test.csv', parse_dates=['datetime'])\n",
     "\n",
-    "df_all = pd.concat([df_train, df_test])"
+    "df_all = pd.concat([df_train, df_test], sort=False)"
    ]
   },
   {


### PR DESCRIPTION
Robiąc ten tutorial natknąłem się na warningi o sortowaniu przy concatenacji. Poprawiłem. W zasadzie z automatu dałem **sort=False**, a z tego co doczytałem, aby pozostawić _status quo_ powinno być True. Choć w sumie, po co ? Z jakiegoś powodu to wyłączyli. :)

/opt/conda/lib/python3.6/site-packages/ipykernel_launcher.py:4: FutureWarning: Sorting because non-concatenation axis is not aligned. 
A future version of pandas will change to not sort by default.
To accept the future behavior, pass 'sort=False'.
To retain the current behavior and silence the warning, pass 'sort=True'.
  after removing the cwd from sys.path.